### PR TITLE
Library changed and improvements

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -1,79 +1,156 @@
-const debug = require('debug')('telegraf:session-mysql')
-const mysql = require('promise-mysql')
-
-var sessions = {}
+const mysql = require('mysql2/promise');
 
 class MySQLSession {
-  constructor (options) {
-    this.options = Object.assign({
-      property: 'session',
-      getSessionKey: (ctx) => {
-        if (ctx.updateType === 'callback_query') {
-          ctx = ctx.update.callback_query.message
-        }
-        if (!ctx.from || !ctx.chat) {
-          return
-        }
-        return `${ctx.chat.id}:${ctx.chat.id}`
-      },
-      store: {}
-    }, options)
+	constructor (options, connection) {
+		this.options = Object.assign({
+			property: 'session',
+			userProperty: '',
+			chatProperty: '',
+			table: 'sessions',
+			interval: 300000,
+			lifetime: 300,
+			getSessionKey: (ctx) => {
+				if (ctx.updateType === 'callback_query') {
+					ctx = ctx.update.callback_query.message;
+				}
+				if (!ctx.from || !ctx.chat) {
+					return;
+				}
+				return [ctx.from.id, ctx.chat.id];
+			}
+		}, options);
+		
+		this.sessions = {};
+		this.sessionsDts = {};
 
-    this.client = mysql.createPool(this.options)
-  }
+		this.client = mysql.createPool(connection);
+		
+		this.client.execute('CREATE TABLE IF NOT EXISTS `' + this.options.table + '` (`user_id` bigint(20) NOT NULL,`chat_id` bigint(20) NOT NULL,`session` JSON NOT NULL,UNIQUE KEY `user_id` (`user_id`,`chat_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8;').then(([rows,fields]) => {
+		}).catch(console.log);
+		
+		this.interval = setInterval(() => {
+			var currnet_time = Math.floor(new Date() / 1000);
+			
+			Object.keys(this.sessionsDts).forEach((key) => {
+				if (currnet_time - this.sessionsDts[key] >= this.options.lifetime) {
+					delete this.sessions[key];
+					delete this.sessionsDts[key];
+				}
+			});
+		}, this.options.interval);
+	}
 
-  getSession (key) {
-    if (sessions[key]) return { then: function (fn) { fn(sessions[key]) } }
-    return this.client.query('SELECT session FROM sessions WHERE id="' + key + '"')
-      .then((json) => {
-        debug('select query', json)
-        let session = {}
-        if (json && json.length) {
-          try {
-            debug('JSON: ', json)
-            session = JSON.parse(unescape(json[0].session))
-            debug('session state', session)
-          } catch (error) {
-            debug('Parse session state failed', error)
-          }
-        }
-        sessions[key] = session
-        return session
-      })
-  }
+	async getSession (user_id, chat_id) {
+		const key = user_id + ':' + chat_id;
+		
+		if (!this.sessions[key]) {
+			let [rows] = await this.client.query('SELECT `session` FROM `' + this.options.table + '` WHERE `user_id` = "' + user_id + '" AND `chat_id` = "' + chat_id + '"');
+			
+			if (rows && rows.length) {
+				this.sessions[key] = rows[0].session;
+			} else {
+				this.sessions[key] = {};
+			}
+			
+			this.sessionsDts[key] = Math.floor(new Date() / 1000);
+		}
+		
+		return this.sessions[key];
+	}
 
-  saveSession (key, session) {
-    if (!session || Object.keys(session).length === 0) {
-      debug('clear session')
-      return this.client.query('DELETE FROM sessions WHERE id="' + key + '"')
-    }
+	async saveSession (user_id, chat_id, session) {
+		if (!session || Object.keys(session).length === 0) {
+			return await this.client.query('DELETE FROM `' + this.options.table + '` WHERE `user_id` = "' + user_id + '" AND `chat_id` = "' + chat_id + '"');
+		}
 
-    debug('save session', session, 'key', key)
+		const sessionString = JSON.stringify(session);
+		
+		return await this.client.query("INSERT INTO `" + this.options.table + "` (`user_id`, `chat_id`, `session`) VALUE ('" + user_id + "', '" + chat_id + "', '" + sessionString + "') ON DUPLICATE KEY UPDATE `session` = '" + sessionString + "';");
+	}
+	
+	destroy() {
+		this.client.end();
+		this.client = null;
+		
+		delete this.options;
+		this.options = null;
+		
+		clearInterval(this.interval);
+		this.interval = null;
+		
+		delete this.sessions;
+		this.sessions = null;
+		
+		delete this.sessionsDts;
+		this.sessionsDts = null;
+	}
 
-    const sessionString = escape(JSON.stringify(session))
-    return this.client.query('INSERT INTO sessions(id,session) value("' + key + '","' + sessionString + '") ' +
-     'on duplicate key update session="' + sessionString + '";')
-  }
-
-  middleware () {
-    return (ctx, next) => {
-      const key = this.options.getSessionKey(ctx)
-      if (!key) {
-        return next()
-      }
-      debug('session key %s', key)
-      return this.getSession(key).then(() => {
-        debug('session value', sessions[key])
+	middleware () {
+		return async (ctx, next) => {
+			const [user_id, chat_id] = this.options.getSessionKey(ctx);
+			
+			if (!user_id || !chat_id) {
+				return next();
+			}
+			
+      let session = null;
+			if (this.options.property) {
+        session = await this.getSession(user_id, chat_id);
+        
         Object.defineProperty(ctx, this.options.property, {
-          get: function () { return sessions[key] },
-          set: function (newValue) { sessions[key] = Object.assign({}, newValue) }
-        })
-        return next().then(() => {
-          return this.saveSession(key, sessions[key])
-        })
-      })
-    }
-  }
+          get: function () { 
+            return session;
+          },
+          set: function (newValue) { 
+            session = Object.assign({}, newValue) ;
+          }
+        });
+      }
+			
+			let userSession = null;
+			
+			if (this.options.userProperty) {
+				userSession = await this.getSession(user_id, 0);
+				
+				Object.defineProperty(ctx, this.options.userProperty, {
+					get: function () { 
+						return userSession;
+					},
+					set: function (newValue) { 
+						userSession = Object.assign({}, newValue) ;
+					}
+				});
+			}
+			
+			let chatSession = null;
+			
+			if (this.options.chatProperty) {
+				chatSession = await this.getSession(0, chat_id);
+				
+				Object.defineProperty(ctx, this.options.chatProperty, {
+					get: function () { 
+						return chatSession;
+					},
+					set: function (newValue) { 
+						chatSession = Object.assign({}, newValue) ;
+					}
+				});
+			}
+			
+			await next();
+			
+      if (session) {
+        await this.saveSession(user_id, chat_id, session);
+      }
+			if (userSession) {
+				await this.saveSession(user_id, 0, userSession);
+			}
+			if (chatSession) {
+				await this.saveSession(0, chat_id, chatSession);
+			}
+			return;
+		}
+	}
 }
 
-module.exports = MySQLSession
+module.exports = MySQLSession;


### PR DESCRIPTION
Define userProperty for user specific session and chatProperty for chat specific session in the options or leave empty or null including default property to disable it
DB connection parameters are passed as second arg in the constructor
Added destroy() method to delete and close db connection
Added session lifetime to keep up in memory and interval to check for the session lifetime to keep memory free and reduce db query
Added table property to set table in the database
Added CREATE TABLE query at startup
Changed id string to 2 fields as chat_id and user_id as numbers to fast up db search
Changed session field to JSON type instead of LONGTEXT
Changed methods to asynchronus