### PR TITLE
Update and fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ $ npm install telegraf-session-mysql
 Module can auto create table in database, but if you want to create manually, use this request
 
 ```SQL
-CREATE TABLE `sessions` (
-  `id` varchar(100) NOT NULL,
-  `session` longtext NOT NULL,
-  PRIMARY KEY (`id`))
+CREATE TABLE IF NOT EXISTS sessions (
+  user_id BIGINT(20) NOT NULL,
+  chat_id BIGINT(20) NOT NULL,
+  session LONGTEXT NOT NULL,
+  UNIQUE KEY user_id(user_id, chat_id)
+) ENGINE = innodb DEFAULT CHARSET = utf8
 ```
 
 ## Example

--- a/examples/simple-bot.js
+++ b/examples/simple-bot.js
@@ -9,17 +9,20 @@ const session = new MySQLSession({
   password: 'root',
   database: 'telegraf_sessions'
 })
+telegraf.use(session.middleware());
 
-telegraf.use(session.middleware())
+(async() => {
+  await session.connect()
 
-telegraf.on('text', (ctx, next) => {
-  ctx.session.counter = ctx.session.counter || 0
-  ctx.session.counter++
-  return next()
-})
+  telegraf.on('text', (ctx, next) => {
+    ctx.session.counter = ctx.session.counter || 0
+    ctx.session.counter++
+    return next()
+  })
 
-telegraf.hears('/stats', (ctx) => {
-  return ctx.reply(`${ctx.session.counter} messages from ${ctx.from.username}`)
-})
+  telegraf.hears('/stats', (ctx) => {
+    return ctx.reply(`${ctx.session.counter} messages from ${ctx.from.username}`)
+  })
 
-telegraf.startPolling(30)
+  telegraf.startPolling(30)
+})()

--- a/lib/session.js
+++ b/lib/session.js
@@ -31,7 +31,7 @@ class MySQLSession {
       (
         user_id BIGINT(20) NOT NULL,
         chat_id BIGINT(20) NOT NULL,
-        session JSON NOT NULL,
+        session LONGTEXT NOT NULL,
         UNIQUE KEY user_id (user_id, chat_id)
       )
       engine=innodb

--- a/lib/session.js
+++ b/lib/session.js
@@ -3,6 +3,8 @@ const debug = require('debug')('telegraf:session-redis')
 
 class MySQLSession {
   constructor (connection, options = {}) {
+    this.connection = connection
+
     this.options = Object.assign({
       property: 'session',
       userProperty: '',
@@ -24,23 +26,6 @@ class MySQLSession {
     this.sessions = {}
     this.sessionsDts = {}
 
-    this.client = mysql.createPool(connection)
-
-    this.client.execute(
-`CREATE TABLE IF NOT EXISTS ${this.options.table}
-      (
-        user_id BIGINT(20) NOT NULL,
-        chat_id BIGINT(20) NOT NULL,
-        session LONGTEXT NOT NULL,
-        UNIQUE KEY user_id (user_id, chat_id)
-      )
-      engine=innodb
-      DEFAULT charset=utf8;`
-    )
-      .catch((err) => {
-        throw new Error("Can't create table for sessions", err)
-      })
-
     this.interval = setInterval(() => {
       const currentTime = Math.floor(new Date() / 1000)
 
@@ -51,6 +36,25 @@ class MySQLSession {
         }
       })
     }, this.options.interval)
+  }
+
+  async connect () {
+    this.client = mysql.createPool(this.connection)
+
+    return this.client.execute(
+      `CREATE TABLE IF NOT EXISTS ${this.options.table}
+      (
+        user_id BIGINT(20) NOT NULL,
+        chat_id BIGINT(20) NOT NULL,
+        session LONGTEXT NOT NULL,
+        UNIQUE KEY user_id (user_id, chat_id)
+      )
+      engine=innodb
+      DEFAULT charset=utf8;`
+    )
+      .catch((err) => {
+        throw new Error(`Can't create table for sessions ${err}`)
+      })
   }
 
   async getSession (userID, chatID) {

--- a/test/session-test.js
+++ b/test/session-test.js
@@ -11,75 +11,91 @@ const options = {
 describe('Telegraf Session', function () {
   it('should retrieve and save session', function (done) {
     const mySQLSession = new MySQLSession(options)
+
     const userID = 1
     const chatID = 2
-    mySQLSession.getSession(userID, chatID)
-      .then((session) => {
-        should.exist(session)
-        session.foo = 42
-        return mySQLSession.saveSession(userID, chatID, session)
-      })
+    mySQLSession.connect()
       .then(() => {
-        return mySQLSession.getSession(userID, chatID)
+        mySQLSession.getSession(userID, chatID)
+          .then((session) => {
+            should.exist(session)
+            session.foo = 42
+            return mySQLSession.saveSession(userID, chatID, session)
+          })
+          .then(() => {
+            return mySQLSession.getSession(userID, chatID)
+          })
+          .then((session) => {
+            should.exist(session)
+            session.should.be.deepEqual({ foo: 42 })
+          })
+          .then(done)
       })
-      .then((session) => {
-        should.exist(session)
-        session.should.be.deepEqual({ foo: 42 })
-      })
-      .then(done)
   })
 
   it('should be defined', function (done) {
     const app = new Telegraf()
     const session = new MySQLSession(options)
-    app.on('text',
-      session.middleware(),
-      (ctx) => {
-        should.exist(ctx.session)
-        ctx.session.foo = 42
-        done()
+    session.connect()
+      .then(() => {
+        app.on('text',
+          session.middleware(),
+          (ctx) => {
+            should.exist(ctx.session)
+            ctx.session.foo = 42
+            done()
+          })
+        app.handleUpdate({message: {chat: {id: 1}, from: {id: 1}, text: 'hey'}})
       })
-    app.handleUpdate({message: {chat: {id: 1}, from: {id: 1}, text: 'hey'}})
   })
 
   it('should handle existing session', function (done) {
     const app = new Telegraf()
     const session = new MySQLSession(options)
-    app.on('text',
-      session.middleware(),
-      (ctx) => {
-        should.exist(ctx.session)
-        ctx.session.should.have.property('foo')
-        ctx.session.foo.should.be.equal(42)
-        done()
+    session.connect()
+      .then(() => {
+        app.on('text',
+          session.middleware(),
+          (ctx) => {
+            should.exist(ctx.session)
+            ctx.session.should.have.property('foo')
+            ctx.session.foo.should.be.equal(42)
+            done()
+          })
+        app.handleUpdate({message: {chat: {id: 1}, from: {id: 1}, text: 'hey'}})
       })
-    app.handleUpdate({message: {chat: {id: 1}, from: {id: 1}, text: 'hey'}})
   })
 
   it('should handle not existing session', function (done) {
     const app = new Telegraf()
     const session = new MySQLSession(options)
-    app.on('text',
-      session.middleware(),
-      (ctx) => {
-        should.exist(ctx.session)
-        ctx.session.should.not.have.property('foo')
-        done()
+    session.connect()
+      .then(() => {
+        app.on('text',
+          session.middleware(),
+          (ctx) => {
+            should.exist(ctx.session)
+            ctx.session.should.not.have.property('foo')
+            done()
+          })
+        app.handleUpdate({message: {chat: {id: 2}, from: {id: 999}, text: 'hey'}})
       })
-    app.handleUpdate({message: {chat: {id: 2}, from: {id: 999}, text: 'hey'}})
   })
 
   it('should handle session reset', function (done) {
     const app = new Telegraf()
     const session = new MySQLSession(options)
-    app.on('text',
-      session.middleware(),
-      (ctx) => {
-        ctx.session = null
-        should.exist(ctx.session)
-        ctx.session.should.not.have.property('foo')
-        done()
+    session.connect()
+      .then(() => {
+        app.on('text',
+          session.middleware(),
+          (ctx) => {
+            ctx.session = null
+            should.exist(ctx.session)
+            ctx.session.should.not.have.property('foo')
+            done()
+          })
+        app.handleUpdate({message: {chat: {id: 1}, from: {id: 1}, text: 'hey'}})
       })
-    app.handleUpdate({message: {chat: {id: 1}, from: {id: 1}, text: 'hey'}})
   })
 })


### PR DESCRIPTION
In my past PR, there is an error, because of a field with type `JSON` . `mysql2` does not return JSON,  it's returns object.

 For some reason when running tests I had some problems, and it returned a string, not an `Object`, after which I added `JSON.parse` and the problem was solved, I do not know why then it returned a string. All the tests were passed, but today I noticed that it does not work correctly. I also noticed that the `JSON` type has been supported since MySQL version 5.7.5 and it makes sense to returns back `LONGTEXT` type, then the problem with JSON parsing will be solved without code changes.

In this PR , I also added a method .connect() to eliminate problems with using the session before creating the table (if it is not created). This behavior sometimes manifested itself in tests. Since the creation of the @FrozDark table was done in the constructor, it would not be a very good practice to return a promise from the constructor, so I made the creation of a connection pool and a table in the database into a separate method.

I have slightly improved the readme and added a new method, as well as updated the examples. I have tested several times, everything passes the tests.

Please republish version ([with unpublish npm version](https://docs.npmjs.com/unpublishing-packages-from-the-registry#unpublishing-a-single-version-of-a-package)) for remove problems with `JSON.parse` and `JSON` type in MySQL

![Screenshot_6](https://user-images.githubusercontent.com/17622604/136468102-a79bafec-c951-4413-88f0-66d0333ccaad.png)
